### PR TITLE
feat: Add command time log

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,24 @@
-version: '2'
+version: "3.9"
+
 services:
   rabbitmq:
-    image: rabbitmq:3-management
+    image: rabbitmq:3.10.8-management-alpine
+    hostname: cli-consumer
     ports:
-      - "15672:15672"
       - "5672:5672"
+      - "15672:15672"
+
+  proxy:
+    image: cloudamqp/amqproxy:v0.8.11
+    environment:
+      AMQP_URL: amqp://connection:5676
+    ports:
+      - "5673:5673"
+
+  connection:
+    image: alpine/socat
+    command: tcp-listen:5676,reuseaddr,fork tcp:rabbitmq:5672
+
+
+volumes:
+  rabbitmq-data: ~


### PR DESCRIPTION
Change logs around the command from 

```
2023/08/03 17:25:42 Processing message...
2023/08/03 17:31:13 Processed !
```

to something like 

```
2023/08/04 09:01:22 Processing message...
2023/08/04 09:01:22 Command write to std*
2023/08/04 09:01:24 Command write to std*
2023/08/04 09:01:26 Command write to std*
2023/08/04 09:01:28 Command write to std*
2023/08/04 09:01:30 Command write to std*
2023/08/04 09:01:32 Command still running after 10.000686809s
2023/08/04 09:01:32 Command write to std*
2023/08/04 09:01:34 Command still running after 12.000758973s
2023/08/04 09:01:34 Command write to std*
2023/08/04 09:01:36 Command still running after 14.001076704s
2023/08/04 09:01:36 Command write to std*
2023/08/04 09:01:38 Command still running after 16.000896622s
2023/08/04 09:01:38 Command write to std*
2023/08/04 09:01:40 Command still running after 18.000237901s
2023/08/04 09:01:40 Command write to std*
2023/08/04 09:01:42 Command still running after 20.000208966s
2023/08/04 09:01:42 Processed (20.051984541s)!

```

After 5 minutes of runtime, the time the command has been running for is output every 30s until it succeeds or run in the ACK timeout 
In addition the command writes  to stdin/stdout will be written asap to stdout instead of buffered 